### PR TITLE
Respect global namespace. Dont use common names.

### DIFF
--- a/cs/lifdscp_stats.cs
+++ b/cs/lifdscp_stats.cs
@@ -4,9 +4,10 @@ $LIFDS_ONLINE_UPDATE_INTERVAL = 10000; //Update list every 10 seconds
 
 $nullObj = new SimObject();
 
-function sqlNullCallback() 
+function sqlNullCallback(%rs) 
 {
-
+	dbi.remove(%rs);
+	%rs.delete();
 }
 
 function sqlExecute(%sql)


### PR DESCRIPTION
Create package for own functions. Use prefix for global functions and variables.
updatePlayer is too common name, which can be used by developers, and/or other mods, which can lead to unexpected behaviour.

You may(or may not) use this patch as is, its just for an example.
